### PR TITLE
THREE is not defined error thrown in Spoke

### DIFF
--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -48,7 +48,7 @@ function WebXRManager( renderer, gl ) {
 	cameraVR.layers.enable( 1 );
 	cameraVR.layers.enable( 2 );
 
-	var poseMatrix = new THREE.Matrix4();
+	var poseMatrix = new Matrix4();
 
 	//
 


### PR DESCRIPTION
Remove THREE reference for Matrix (typo bug)